### PR TITLE
Implement logic to handle no-code deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "stackmgmt",
     "description": "Abstraction for managing stack deployment and related settings.",
-    "version": "1.0.0",
     "dependencies": {
         "@pulumi/command": "^1.0.2",
         "@pulumi/pulumi": "^3.160.0",

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -43,7 +43,7 @@ export class StackSettings extends pulumi.ComponentResource {
 
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
-      if (deploymentConfig != null) { // it's not a no-code deployment
+      if (deploymentConfig) { // it's not a no-code deployment
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})
       } else {

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -44,7 +44,6 @@ export class StackSettings extends pulumi.ComponentResource {
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
       /// DEBUG
-      pulumi.log.info(`Deployment settings for stack ${stackFqdn} are: ${JSON.stringify(deploymentConfig)}`)
       if (deploymentConfig) { // it's not a no-code deployment
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -46,34 +46,34 @@ export class StackSettings extends pulumi.ComponentResource {
       if (deploymentConfig != null) { // it's not a no-code deployment
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})
-        //// TTL Schedule ////
-        // Calculate the TTL time based on the TTL minutes passed in or default to 8 hours.
-        const ttlTime = new pulumitime.Offset("ttltime", {offsetMinutes: (args.ttlMinutes || (8*60))}, { parent: this }).rfc3339
-        const ttlSchedule = new pulumiservice.TtlSchedule(`${name}-ttlschedule`, {
-          organization: org,
-          project: project,
-          stack: stack,
-          timestamp: ttlTime,
-          deleteAfterDestroy: false,
-        }, { parent: this, dependsOn: [deploymentSettings] }) 
-
-        //// Drift Schedule ////
-        let remediation = true // assume we want to remediate
-        if ((args.driftManagement) && (args.driftManagement != "Correct")) {
-          remediation = false // only do drift detection
-        }
-        const driftSchedule = new pulumiservice.DriftSchedule(`${name}-driftschedule`, {
-          organization: org,
-          project: project,
-          stack: stack,
-          scheduleCron: "0 * * * *",
-          autoRemediate: remediation,
-        }, { parent: this, dependsOn: [deploymentSettings] }) 
       } else {
         // Need to set the delete_stack tag to "StackOnly" to prevent the purge automation from trying to delete the repo which points at the 
         // templates repo - we definitely don't want to delete the templates repo.
         setTag(stackFqdn, deleteStackTagName, "StackOnly")
       }
+      //// TTL Schedule ////
+      // Calculate the TTL time based on the TTL minutes passed in or default to 8 hours.
+      const ttlTime = new pulumitime.Offset("ttltime", {offsetMinutes: (args.ttlMinutes || (8*60))}, { parent: this }).rfc3339
+      const ttlSchedule = new pulumiservice.TtlSchedule(`${name}-ttlschedule`, {
+        organization: org,
+        project: project,
+        stack: stack,
+        timestamp: ttlTime,
+        deleteAfterDestroy: false,
+      }, { parent: this }) 
+
+      //// Drift Schedule ////
+      let remediation = true // assume we want to remediate
+      if ((args.driftManagement) && (args.driftManagement != "Correct")) {
+        remediation = false // only do drift detection
+      }
+      const driftSchedule = new pulumiservice.DriftSchedule(`${name}-driftschedule`, {
+        organization: org,
+        project: project,
+        stack: stack,
+        scheduleCron: "0 * * * *",
+        autoRemediate: remediation,
+      }, { parent: this }) 
     })
 
     //// Team Stack Assignment ////

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -38,11 +38,13 @@ export class StackSettings extends pulumi.ComponentResource {
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
       if (deploymentConfig) { // it's not a no-code deployment
+        pulumi.log.info(`#1 Deployment settings for ${stack}: ${JSON.stringify(deploymentConfig)}`)
         // Non-no-code so we need to manage the purge settings.
         deleteStackTagValue = args.deleteStack || "True"
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})
       } else {
+        pulumi.log.info(`#2 Deployment settings for ${stack}: ${JSON.stringify(deploymentConfig)}`)
         // Need to set the delete_stack tag to "StackOnly" to prevent the purge automation from trying to delete the repo which points at the 
         // templates repo - we definitely don't want to delete the templates repo.
         deleteStackTagValue = "StackOnly"

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -43,7 +43,6 @@ export class StackSettings extends pulumi.ComponentResource {
 
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
-      /// DEBUG
       if (deploymentConfig) { // it's not a no-code deployment
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})

--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -43,6 +43,8 @@ export class StackSettings extends pulumi.ComponentResource {
 
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
+      /// DEBUG
+      pulumi.log.info(`Deployment settings for stack ${stackFqdn} are: ${JSON.stringify(deploymentConfig)}`)
       if (deploymentConfig) { // it's not a no-code deployment
         // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
         const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -79,10 +79,8 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
   // const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
   getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
-    pulumi.log.info(`Base deployment settings for stack ${baseStack} are: ${JSON.stringify(baseDeploymentSettings)}`)
-
     // This is not a no-code deployment so we need to manage the deployment settings. 
-    if (baseDeploymentSettings.sourceContext.git?.branch) {
+    if (baseDeploymentSettings.sourceContext.git) {
 
       // Use what was in the base deployment settings.
       let branch = baseDeploymentSettings.sourceContext.git?.branch || "refs/heads/main"
@@ -130,8 +128,8 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
         }
       }
     } 
+    return(deploymentConfig)
   })
-  pulumi.log.info(`Deployment settings being returned are: ${JSON.stringify(deploymentConfig)}`)
   return(deploymentConfig)
 }
 

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -74,11 +74,11 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
   if (stack.includes(`pr-pulumi-${org}-${project}`)) {
     baseStack = stack
   }
-  const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
-    let deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+  let deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+  // const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
+  getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
-    /// DEBUG
     pulumi.log.info(`Base deployment settings for stack ${baseStack} are: ${JSON.stringify(baseDeploymentSettings)}`)
 
     // Check if this is a no-code deployment. If not, then we need to manage the deployment settings. 
@@ -130,8 +130,8 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
         }
       }
     } 
-    return(deploymentConfig)
   })
+  pulumi.log.info(`Deployment settings being returned are: ${JSON.stringify(deploymentConfig)}`)
   return(deploymentConfig)
 }
 

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -82,7 +82,7 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
     pulumi.log.info(`Base deployment settings for stack ${baseStack} are: ${JSON.stringify(baseDeploymentSettings)}`)
 
     // This is not a no-code deployment so we need to manage the deployment settings. 
-    if (baseDeploymentSettings.sourceContext.template?.sourceType != "no-code") {
+    if (baseDeploymentSettings.sourceContext.git?.branch) {
 
       // Use what was in the base deployment settings.
       let branch = baseDeploymentSettings.sourceContext.git?.branch || "refs/heads/main"

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -75,13 +75,13 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
     baseStack = stack
   }
 
-  let deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+  var deploymentConfig: pulumiservice.DeploymentSettingsArgs | undefined = undefined
   // const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
   getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
     pulumi.log.info(`Base deployment settings for stack ${baseStack} are: ${JSON.stringify(baseDeploymentSettings)}`)
 
-    // Check if this is a no-code deployment. If not, then we need to manage the deployment settings. 
+    // This is not a no-code deployment so we need to manage the deployment settings. 
     if (baseDeploymentSettings.sourceContext.template?.sourceType != "no-code") {
 
       // Use what was in the base deployment settings.

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -61,7 +61,8 @@ const getDeploymentSettings = async (org: string, project: string, stack: string
 }
 
 // Builds deployment settings using existing settings and modifying them as needed.
-export const buildDeploymentConfig = async (npwStack: string, stack: string, org: string, project: string, pulumiAccessToken: string) => {
+var deploymentConfig: pulumiservice.DeploymentSettingsArgs | undefined
+export const buildDeploymentConfig: (npwStack: string, stack: string, org: string, project: string, pulumiAccessToken: string) => Promise<pulumiservice.DeploymentSettingsArgs | undefined | void> = async(npwStack: string, stack: string, org: string, project: string, pulumiAccessToken: string) => {
 
   // Figure out if stack is created by user (e.g. pulumi stack init ...)
   let userCreatedStack = false
@@ -75,12 +76,15 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
     baseStack = stack
   }
 
-  var deploymentConfig: pulumiservice.DeploymentSettingsArgs | undefined = undefined
   // const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
   getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
+    pulumi.log.info(`Base deployment settings for ${baseStack}: ${JSON.stringify(baseDeploymentSettings)}`)
+
     // This is not a no-code deployment so we need to manage the deployment settings. 
     if (baseDeploymentSettings.sourceContext.git) {
+
+      pulumi.log.info("processing deployment settings")
 
       // Use what was in the base deployment settings.
       let branch = baseDeploymentSettings.sourceContext.git?.branch || "refs/heads/main"
@@ -128,9 +132,11 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
         }
       }
     } 
+    pulumi.log.info(`Return #1: ${JSON.stringify(deploymentConfig)}`)
     return(deploymentConfig)
   })
-  return(deploymentConfig)
+  // pulumi.log.info(`Return #2: ${JSON.stringify(deploymentConfig)}`)
+  // return(deploymentConfig)
 }
 
 // Deployment Settings API Related //

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -76,7 +76,10 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
   }
   const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
-    var deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+    let deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+
+    /// DEBUG
+    pulumi.log.info(`Base deployment settings for stack ${baseStack} are: ${JSON.stringify(baseDeploymentSettings)}`)
 
     // Check if this is a no-code deployment. If not, then we need to manage the deployment settings. 
     if (baseDeploymentSettings.sourceContext.template?.sourceType != "no-code") {

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -76,7 +76,7 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
   }
   const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
-    let deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
+    var deploymentConfig = {} as pulumiservice.DeploymentSettingsArgs
 
     // Check if this is a no-code deployment. If not, then we need to manage the deployment settings. 
     if (baseDeploymentSettings.sourceContext.template?.sourceType != "no-code") {


### PR DESCRIPTION
No-code deployments do not have github info and actually point at the templates repo the project was launched from.
Therefore, this requires:
- Not configuring the deployment settings
- Changing the delete_stack tag so the purge doesn't try to delete the repo for the stack.