### PR TITLE
Implements no-code support

### DIFF
--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -24,16 +24,6 @@ export class StackSettings extends pulumi.ComponentResource {
     const stack = pulumi.getStack()
     const stackFqdn = `${org}/${project}/${stack}`
 
-    //// Purge Stack Tag ////
-    // This stack tag indicates whether or not the purge automation should delete the stack.
-    // Because the tag needs to remain on destroy and the provider balks if the stack tag already exists 
-    // (which would be the case on a pulumi up after a destroy), using the pulumiservice provider for this tag is not feasible.
-    // So, just hit the Pulumi Cloud API set the tag and that way it is not deleted on destroy.
-    let tagName = "delete_stack"
-    // If deleteStack is not set, default to "True" since we generally want things cleaned up.
-    let tagValue = args.deleteStack || "True"
-    setTag(stackFqdn, tagName, tagValue)
-    
     //// Deployment Settings Management ////
     // If a new stack is created by the user (e.g. `pulumi stack init pequod/test`) there are a couple of assumptions:
     // - It tracks to a branch with the same name as the stack.
@@ -41,9 +31,33 @@ export class StackSettings extends pulumi.ComponentResource {
     // Although this is somewhat restrictive, it is sufficient for the general use-case of creating new stacks.
     // Get the settings from the original NPW-created stack or review stack to reuse as a basis for new deployment settings for any (non-review) new stacks.
 
+    // This is the value for the delete_stack tag that is set on the stack.
+    // It varies depending on whether the stack is no-code or not
+    var deleteStackTagValue: string 
+
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
-    // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
-      const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})
+      // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
+      if (deploymentConfig.sourceContext) {
+        pulumi.log.info(`#1 Deployment settings for ${stack}: ${JSON.stringify(deploymentConfig)}`)
+        // Non-no-code so we need to manage the purge settings.
+        deleteStackTagValue = args.deleteStack || "True"
+        // Set the stack's deployment settings based on what was returned by the buildDeploymentSettings function.
+        const deploymentSettings = new pulumiservice.DeploymentSettings(`${name}-deployment-settings`, deploymentConfig, {parent: this, retainOnDelete: true})
+      } else {
+        pulumi.log.info(`#2 Deployment settings for ${stack}: ${JSON.stringify(deploymentConfig)}`)
+        // Need to set the delete_stack tag to "StackOnly" to prevent the purge automation from trying to delete the repo which points at the 
+        // templates repo - we definitely don't want to delete the templates repo.
+        deleteStackTagValue = "StackOnly"
+      }
+
+      //// Purge Stack Tag ////
+      // This stack tag indicates whether or not the purge automation should delete the stack.
+      // Because the tag needs to remain on destroy and the provider balks if the stack tag already exists 
+      // (which would be the case on a pulumi up after a destroy), using the pulumiservice provider for this tag is not feasible.
+      // So, just hit the Pulumi Cloud API set the tag and that way it is not deleted on destroy.
+      const deleteStackTagName = "delete_stack"
+      setTag(stackFqdn, deleteStackTagName, deleteStackTagValue)
+
       //// TTL Schedule ////
       // Calculate the TTL time based on the TTL minutes passed in or default to 8 hours.
       const ttlTime = new pulumitime.Offset("ttltime", {offsetMinutes: (args.ttlMinutes || (8*60))}, { parent: this }).rfc3339
@@ -53,7 +67,7 @@ export class StackSettings extends pulumi.ComponentResource {
         stack: stack,
         timestamp: ttlTime,
         deleteAfterDestroy: false,
-      }, { parent: this, dependsOn: [deploymentSettings] }) 
+      }, { parent: this }) 
 
       //// Drift Schedule ////
       let remediation = true // assume we want to remediate
@@ -66,9 +80,8 @@ export class StackSettings extends pulumi.ComponentResource {
         stack: stack,
         scheduleCron: "0 * * * *",
         autoRemediate: remediation,
-      }, { parent: this, dependsOn: [deploymentSettings] }) 
+      }, { parent: this }) 
     })
-
     //// Team Stack Assignment ////
     // If no team name given, then assign to the "DevTeam"
     const teamAssignment = args.teamAssignment ?? "DevTeam"

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -125,8 +125,11 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
     // Check if this is actually a no-code deployment.
     // If so, we'll overload the branch setting to indicate it's no-code 
     if  (baseDeploymentSettings.sourceContext.template) {
+      pulumi.log.info(`No-code deployment detected for ${stack}.`)
       deploymentConfig.sourceContext = undefined
     }
+
+    pulumi.log.info(`After no-code check`)
 
     return(deploymentConfig)
   })

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -98,7 +98,7 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
 
     // Construct the deployment settings.
     // const deploymentSettings: pulumiservice.DeploymentSettingsArgs = {
-    const deploymentConfig: pulumiservice.DeploymentSettingsArgs = {
+    let deploymentConfig: pulumiservice.DeploymentSettingsArgs = {
       organization: org,
       project: project,
       stack: stack,
@@ -121,6 +121,13 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
         }
       }
     }
+
+    // Check if this is actually a no-code deployment.
+    // If so, we'll overload the branch setting to indicate it's no-code 
+    if  (baseDeploymentSettings.sourceContext.template) {
+      deploymentConfig.sourceContext = undefined
+    }
+
     return(deploymentConfig)
   })
   return(deploymentConfig)
@@ -141,11 +148,15 @@ interface OperationContext {
   options?: object
 }
 interface SourceContext {
-  git: Git
+  git?: Git
+  template?: Template
 }
 interface Git {
   branch: string
   repoDir?: string
+}
+interface Template {
+  sourceType: string
 }
 interface GitHub {
   repository: string


### PR DESCRIPTION
No-code support requires:
- Not trying to configure deployment settings
- Changing the delete_stack tag to StackOnly to keep the purge from deleting the templates repo since that is the repo that is associated with no-code deployments.