### PR TITLE
Mitch/nsw support

### DIFF
--- a/stackSettings.ts
+++ b/stackSettings.ts
@@ -25,17 +25,12 @@ export class StackSettings extends pulumi.ComponentResource {
     const stackFqdn = `${org}/${project}/${stack}`
 
     //// Deployment Settings Management ////
-    // If a new stack is created by the user (e.g. `pulumi stack init pequod/test`) there are a couple of assumptions:
-    // - It tracks to a branch with the same name as the stack.
-    // - It always has the same deployment settings (other than the branch name) as the original NPW-created stack.
-    // Although this is somewhat restrictive, it is sufficient for the general use-case of creating new stacks.
-    // Get the settings from the original NPW-created stack or review stack to reuse as a basis for new deployment settings for any (non-review) new stacks.
-
-    // This is the value for the delete_stack tag that is set on the stack.
-    // It varies depending on whether the stack is no-code or not
-    var deleteStackTagValue: string 
-
     buildDeploymentConfig(npwStack, stack, org, project, pulumiAccessToken).then(deploymentConfig => {
+
+      // This is the value for the delete_stack tag that is set below on the stack. 
+      // It varies depending on whether the stack is no-code or not
+      var deleteStackTagValue: string 
+
       // Check if this is a no-code deployment. If not, then we need to manage the deployment settings.
       if (deploymentConfig.sourceContext) {
         // Non-no-code so we need to manage the purge settings.

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -67,17 +67,10 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
   // So we do the same.
   const baseStack = npwStack
 
-  // // Figure out if stack is created by user (e.g. pulumi stack init ...)
-  // let userCreatedStack = false
-  // if ((stack != npwStack) && !(stack.includes(`pr-pulumi-${org}-${project}`))) {
-  //   userCreatedStack = true
-  // }
-
-  // // Get the settings from the original NPW-created stack or review stack to reuse as a basis for new deployment settings for any (non-review) new stacks.
-  // let baseStack = npwStack
-  // if (stack.includes(`pr-pulumi-${org}-${project}`)) {
-  //   baseStack = stack
-  // }
+  // Get the deployment settings from the original stack and use them as a basis for tweaking the stack's deployment settings.
+  // The main tweaks are:
+  // - enable caching
+  // - add the PULUMI_ACCESS_TOKEN as an environment variable for the deployment so it has the permissions needed to access other stacks.
   const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
     // Use what was in the base deployment settings.

--- a/stackSettingsUtils.ts
+++ b/stackSettingsUtils.ts
@@ -63,32 +63,28 @@ const getDeploymentSettings = async (org: string, project: string, stack: string
 // Builds deployment settings using existing settings and modifying them as needed.
 export const buildDeploymentConfig = async (npwStack: string, stack: string, org: string, project: string, pulumiAccessToken: string) => {
 
-  // Figure out if stack is created by user (e.g. pulumi stack init ...)
-  let userCreatedStack = false
-  if ((stack != npwStack) && !(stack.includes(`pr-pulumi-${org}-${project}`))) {
-    userCreatedStack = true
-  }
+  // In the new NSW world, we'll always assume Pulumi Cloud has primed the deployment settings for new stacks from the original stack.
+  // So we do the same.
+  const baseStack = npwStack
 
-  // Get the settings from the original NPW-created stack or review stack to reuse as a basis for new deployment settings for any (non-review) new stacks.
-  let baseStack = npwStack
-  if (stack.includes(`pr-pulumi-${org}-${project}`)) {
-    baseStack = stack
-  }
+  // // Figure out if stack is created by user (e.g. pulumi stack init ...)
+  // let userCreatedStack = false
+  // if ((stack != npwStack) && !(stack.includes(`pr-pulumi-${org}-${project}`))) {
+  //   userCreatedStack = true
+  // }
+
+  // // Get the settings from the original NPW-created stack or review stack to reuse as a basis for new deployment settings for any (non-review) new stacks.
+  // let baseStack = npwStack
+  // if (stack.includes(`pr-pulumi-${org}-${project}`)) {
+  //   baseStack = stack
+  // }
   const deploymentConfig = getDeploymentSettings(org, project, baseStack).then(baseDeploymentSettings => {
 
     // Use what was in the base deployment settings.
     let branch = baseDeploymentSettings.sourceContext.git?.branch || "refs/heads/main"
 
-    ///// Given the new "New Stack Wizard" capability, we can't assume that the stack name is the same as the branch name.
-    ///// So this logic is being disabled for now. 
-    ///// If you create a new stack on the command line and it has it's own branch, then you'll need to update the branch in the deployment settings in the UI for the time being.
-    ///// TODO: Come up with a better flow that works for NSW and CLI created stacks.
-    // // But, if this is a user-created stack, then we need to modify the source context settings to point at a branch name that matches the stack name.
-    // if (userCreatedStack) {
-    //   branch = "refs/heads/"+stack
-    // }
-
-    // Carry over the github settings as-is
+    // Carry over the github settings from the original stack as-is
+    // This means that all stacks live on the same branch and repo as the original stack.
     const githubSettingsStringified:pulumi.Output<string> = pulumi.jsonStringify({
       repository: baseDeploymentSettings.gitHub?.repository,
       paths: baseDeploymentSettings.gitHub?.paths,
@@ -128,7 +124,7 @@ export const buildDeploymentConfig = async (npwStack: string, stack: string, org
     }
 
     // Check if this is actually a no-code deployment.
-    // If so, we'll overload the branch setting to indicate it's no-code 
+    // If so, we'll overload the branch setting to indicate it's no-code. 
     if  (baseDeploymentSettings.sourceContext.template) {
       deploymentConfig.sourceContext = undefined
     }


### PR DESCRIPTION
Tweaks to align to the UI's NSW approach.
Mainly this meant assuming the main branch for all stacks and using the original stack as the basis for other stack's deployment config.